### PR TITLE
plot_coords.py: basemap-->cartopy

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   - netcdf4 >=1.1.9
   - matplotlib
   - basemap
-  - cartopy
   - thredds_crawler
   - seawater
 
@@ -29,7 +28,6 @@ requirements:
   - netcdf4 >=1.1.9
   - matplotlib
   - basemap
-  - cartopy
   - thredds_crawler
   - seawater
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   - netcdf4 >=1.1.9
   - matplotlib
   - basemap
+  - cartopy
   - thredds_crawler
   - seawater
 
@@ -28,6 +29,7 @@ requirements:
   - netcdf4 >=1.1.9
   - matplotlib
   - basemap
+  - cartopy
   - thredds_crawler
   - seawater
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
 - scipy
 - netcdf4
 - matplotlib
-- basemap
+- cartopy
 - qt
 - pyqt
 - cftime=1.4.1

--- a/plotting/plot_coords.py
+++ b/plotting/plot_coords.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
-Plot the domain boundaries and show the different locations of the rim width (increasing number should go inwards)
+Plot the domain boundaries and show the different locations of the rim width.
 
+Map showing location of boundaries. Rim width number increases inwards.
 Benchmark data example useage:
 python plotting/plot_coords.py outputs/NNA_R12_bdyT_y1979m11.nc outputs/coordinates.bdy.nc
 """
@@ -41,12 +42,27 @@ fig = plt.figure()
 ax = fig.add_subplot(111, projection=crs)
 
 # Plot the data
-cs1 = ax.pcolormesh(bdy_lon[:, :], bdy_lat[:, :], bdy_msk, cmap="jet", vmin=-0.5, vmax=9.5, transform=crs)
+cs1 = ax.pcolormesh(
+    bdy_lon[:, :],
+    bdy_lat[:, :],
+    bdy_msk,
+    cmap="jet",
+    vmin=-0.5,
+    vmax=9.5,
+    transform=crs,
+)
 
 # Add geographic features
-ax.add_feature(cfeature.NaturalEarthFeature('physical', 'land',
-            '50m', edgecolor='black', alpha=0.7,
-            facecolor=cfeature.COLORS['land']))
+ax.add_feature(
+    cfeature.NaturalEarthFeature(
+        "physical",
+        "land",
+        "50m",
+        edgecolor="black",
+        alpha=0.7,
+        facecolor=cfeature.COLORS["land"],
+    )
+)
 
 # Coordinates to limit map area
 bounds = [-25, 20, 37, 67]
@@ -58,13 +74,21 @@ ax.set_xlabel("Longitude")
 ax.set_ylabel("Latitude")
 
 # Add gridlines
-gl = ax.gridlines(crs=ccrs.PlateCarree(), draw_labels=True,
-                  linewidth=2, color='gray', alpha=0.5, linestyle='--')
+gl = ax.gridlines(
+    crs=ccrs.PlateCarree(),
+    draw_labels=True,
+    linewidth=2,
+    color="gray",
+    alpha=0.5,
+    linestyle="--",
+)
 gl.top_labels = False
 gl.right_labels = False
 
 # Add a colorbar
-cb = plt.colorbar(cs1, orientation="vertical", shrink=0.75, aspect=30, fraction=0.1, pad=0.05)
+cb = plt.colorbar(
+    cs1, orientation="vertical", shrink=0.75, aspect=30, fraction=0.1, pad=0.05
+)
 cb.set_label("RimWidth Number")
 cb.set_ticks(np.arange(10))
 

--- a/plotting/plot_coords.py
+++ b/plotting/plot_coords.py
@@ -95,4 +95,4 @@ cb.set_label("RimWidth Number")
 cb.set_ticks(np.arange(10))
 
 # Save the figure
-fig.savefig("coords.png")
+fig.savefig("coords.png", dpi=300)

--- a/plotting/plot_coords.py
+++ b/plotting/plot_coords.py
@@ -35,7 +35,7 @@ for f in range(len(bdy_it)):
     bdy_msk[bdy_jt[f,], bdy_it[f,]] = bdy_rt[f,]
 
 # Define the projection
-crs = ccrs.LambertConformal(central_latitude=57.0, central_longitude=-12.5)
+crs = ccrs.PlateCarree()
 
 # Create a figure and axes
 fig = plt.figure()
@@ -75,7 +75,7 @@ ax.set_ylabel("Latitude")
 
 # Add gridlines
 gl = ax.gridlines(
-    crs=ccrs.PlateCarree(),
+    crs=crs,
     draw_labels=True,
     linewidth=2,
     color="gray",
@@ -84,6 +84,8 @@ gl = ax.gridlines(
 )
 gl.top_labels = False
 gl.right_labels = False
+gl.bottom_labels = True
+gl.left_labels = True
 
 # Add a colorbar
 cb = plt.colorbar(

--- a/plotting/plot_coords.py
+++ b/plotting/plot_coords.py
@@ -28,7 +28,7 @@ bdy_rt = np.squeeze(rootgrp.variables["nbrt"][:])
 rootgrp.close()
 
 # Mask the invalid values
-bdy_msk = np.ma.masked_where(bdy_msk < 0, bdy_msk)
+bdy_msk = np.ma.masked_where(bdy_msk <= 0, bdy_msk)
 
 # Update the values in the mask
 for f in range(len(bdy_it)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
   "scipy",
   "numpy",
   "matplotlib",
-  "basemap",
   "cartopy",
   "thredds_crawler",
   "seawater",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "numpy",
   "matplotlib",
   "basemap",
+  "cartopy",
   "thredds_crawler",
   "seawater",
   "pyqt5",


### PR DESCRIPTION
Convert use of `basemap` to `cartopy` in `plot_coords.py`

Note this also requires `cartopy` to be invoked in the environment and package build.

(For now I am adding cartopy, rather than replacing basemap. As I am not confident that basemap does not have other dependencies.)
**Update**: remove basemap

**Acceptance Criteria:**
- [x] the following produce a beautiful basemap-free plot (@jdha)
```
python plotting/plot_coords.py outputs/NNA_R12_bdyT_y1979m11.nc outputs/coordinates.bdy.nc
```
- [x] happy with the settings edits in yaml etc files (@JMorado)