### PR TITLE
#53 error catching to time interp

### DIFF
--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -972,13 +972,15 @@ class Extract:
         Get time delta for time_counter and number of timesteps per day. Checks
         if time steps are uniform.
 
-        Input
-        -----
-        time_counter: model time coordinate
+        Parameters
+        ----------
+        time_counter
+            model time coordinate
 
-        Output
-        ------
-        deltaT: length of time step
+        Returns
+        -------
+        deltaT
+            length of time step
         """
         
         # get time derivative
@@ -989,7 +991,7 @@ class Extract:
             self.logger.warning('time interpolation expects uniform time step.')
             self.logger.warning('time_counter is not uniform.')
          
-        # get  number of timesteps per day
+        # get  number of timesteps per day (zero if deltaT > 86400)
         dstep = 86400 // int(deltaT[0])
 
         return deltaT[0], dstep

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -1043,9 +1043,6 @@ class Extract:
         # get deltaT and number of time steps per day (dstep)
         del_t, dstep = self.time_delta(time_counter)
 
-        # If time freq. is greater than 86400s
-        # TODO put in an error handler for the unlikely event of frequency not a
-        # multiple of 86400 | data are annual means
         if self.key_vec is True:
             if self.rot_dir == "i":
                 varnams = [

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -1031,7 +1031,7 @@ class Extract:
             time_counter[t] = tmp_cal.date2num(
                 self.d_bdy[self.var_nam[var_id]]["date"][t]
             )
- 
+
         date_000 = datetime(year, month, 1, 12, 0, 0)
         if month < 12:
             date_end = datetime(year, month + 1, 1, 12, 0, 0)
@@ -1066,7 +1066,7 @@ class Extract:
                 axis=0,
                 bounds_error=True,
             )
-            ds = intfn(target_time)
+            self.d_bdy[v][year]["data"] = intfn(target_time)
 
         # update time_counter
         self.time_counter = target_time

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -969,8 +969,10 @@ class Extract:
 
     def time_delta(self, time_counter):
         """
-        Get time delta for time_counter and number of timesteps per day. Checks
-        if time steps are uniform.
+        Get time delta and number of time steps per day.
+
+        Calculates difference between time steps for time_counter and checks
+        these are uniform. Then retrives the number of time steps per day.
 
         Parameters
         ----------
@@ -981,16 +983,17 @@ class Extract:
         -------
         deltaT
             length of time step
+        dstep
+            number of time steps per day
         """
-        
         # get time derivative
         deltaT = np.diff(time_counter)
 
         # check for uniform time steps
         if not np.all(deltaT == deltaT[0]):
-            self.logger.warning('time interpolation expects uniform time step.')
-            self.logger.warning('time_counter is not uniform.')
-         
+            self.logger.warning("time interpolation expects uniform time step.")
+            self.logger.warning("time_counter is not uniform.")
+
         # get  number of timesteps per day (zero if deltaT > 86400)
         dstep = 86400 // int(deltaT[0])
 
@@ -1008,7 +1011,6 @@ class Extract:
         accepted: gregorian | standard, proleptic_gregorian, noleap | 365_day,
         360_day or julian.*
         """
-        
         # RDP: this could be made more flexible to interpolate to other deltaTs
 
         # Extract time information
@@ -1061,7 +1063,7 @@ class Extract:
 
         # interpolate
         for v in varnams:
-            if del_t >= 86400.0: # upsampling
+            if del_t >= 86400.0:  # upsampling
                 intfn = interp1d(
                     time_counter,
                     self.d_bdy[v][year]["data"][:, :, :],
@@ -1069,8 +1071,8 @@ class Extract:
                     bounds_error=True,
                 )
                 self.d_bdy[v][year]["data"] = intfn(target_time)
-                self.time_counter = target_time 
-            else:                # downsampling
+                self.time_counter = target_time
+            else:  # downsampling
                 for t in range(dstep):
                     intfn = interp1d(
                         time_counter[t::dstep],

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -1031,7 +1031,7 @@ class Extract:
             time_counter[t] = tmp_cal.date2num(
                 self.d_bdy[self.var_nam[var_id]]["date"][t]
             )
-
+ 
         date_000 = datetime(year, month, 1, 12, 0, 0)
         if month < 12:
             date_end = datetime(year, month + 1, 1, 12, 0, 0)
@@ -1060,28 +1060,19 @@ class Extract:
 
         # interpolate
         for v in varnams:
-            if del_t >= 86400.0:  # upsampling
-                intfn = interp1d(
-                    time_counter,
-                    self.d_bdy[v][year]["data"][:, :, :],
-                    axis=0,
-                    bounds_error=True,
-                )
-                self.d_bdy[v][year]["data"] = intfn(target_time)
-                self.time_counter = target_time
-            else:  # downsampling
-                for t in range(dstep):
-                    intfn = interp1d(
-                        time_counter[t::dstep],
-                        self.d_bdy[v].data[t::dstep, :, :],
-                        axis=0,
-                        bounds_error=True,
-                    )
-                    self.d_bdy[v].data[t::dstep, :, :] = intfn(target_time)
+            intfn = interp1d(
+                time_counter,
+                self.d_bdy[v][year]["data"],
+                axis=0,
+                bounds_error=True,
+            )
+            ds = intfn(target_time)
 
-        # self.time_counter = time_counter
+        # update time_counter
+        self.time_counter = target_time
 
-    #        self.time_counter = len(self.d_bdy[v][year]['data'][:,0,0])
+        # RDP: self.d_bdy[v]["date"] is not updated during interpolation, but
+        #      self.time_counter is. This could be prone to unexpected errors.
 
     def write_out(self, year, month, ind, unit_origin):
         """

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -1060,13 +1060,23 @@ class Extract:
 
         # interpolate
         for v in varnams:
-            intfn = interp1d(
-                time_counter,
-                self.d_bdy[v][year]["data"],
-                axis=0,
-                bounds_error=True,
-            )
-            self.d_bdy[v][year]["data"] = intfn(target_time)
+            if del_t >= 86400.0:  # upsampling
+                intfn = interp1d(
+                    time_counter,
+                    self.d_bdy[v][year]["data"][:, :, :],
+                    axis=0,
+                    bounds_error=True,
+                )
+                self.d_bdy[v][year]["data"] = intfn(target_time)
+            else:  # downsampling
+                for t in range(dstep):
+                    intfn = interp1d(
+                        time_counter[t::dstep],
+                        self.d_bdy[v].data[t::dstep, :, :],
+                        axis=0,
+                        bounds_error=True,
+                    )
+                    self.d_bdy[v].data[t::dstep, :, :] = intfn(target_time)
 
         # update time_counter
         self.time_counter = target_time

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -1056,20 +1056,21 @@ class Extract:
         else:
             varnams = self.var_nam
 
-        if del_t >= 86400.0: # upsampling
-            for v in varnams:
+        # target time index
+        target_time = np.arange(time_000, time_end, 86400)
+
+        # interpolate
+        for v in varnams:
+            if del_t >= 86400.0: # upsampling
                 intfn = interp1d(
                     time_counter,
                     self.d_bdy[v][year]["data"][:, :, :],
                     axis=0,
                     bounds_error=True,
                 )
-                self.d_bdy[v][year]["data"] = intfn(
-                    np.arange(time_000, time_end, 86400)
-                )
-                self.time_counter = np.arange(time_000, time_end, 86400)
-        else:                # downsampling
-            for v in varnams:
+                self.d_bdy[v][year]["data"] = intfn(target_time)
+                self.time_counter = target_time 
+            else:                # downsampling
                 for t in range(dstep):
                     intfn = interp1d(
                         time_counter[t::dstep],
@@ -1077,9 +1078,8 @@ class Extract:
                         axis=0,
                         bounds_error=True,
                     )
-                    self.d_bdy[v].data[t::dstep, :, :] = intfn(
-                        np.arange(time_000, time_end, 86400)
-                    )
+                    self.d_bdy[v].data[t::dstep, :, :] = intfn(target_time)
+
         # self.time_counter = time_counter
 
     #        self.time_counter = len(self.d_bdy[v][year]['data'][:,0,0])


### PR DESCRIPTION
Adding error handling for the time interpolation.

Closes #53 

Tasks:
- [x] set warning for non-uniform time steps
- [x] add warning if using annual means (details in TO DO of time_interpolation() )
- [x] either add IMMERSE logging tasks or create new issue for these
- [x] Test changes are sensible