### PR TITLE
124 time interp

### DIFF
--- a/inputs/namelist_local.bdy
+++ b/inputs/namelist_local.bdy
@@ -87,6 +87,8 @@
     nn_month_end    = 11          !  month end (default = 12 is years>1)
     sn_dst_calendar = 'gregorian' !  output calendar format
     nn_base_year    = 1960        !  base year for time counter
+    ln_time_interpolation = .true. !  set to false to use parent frequency and calender
+                                   !  for monthly only
 	! location of TPXO7.2 data
 	sn_tide_grid   = './inputs/tpxo7.2/grid_tpxo7.2.nc'
 	sn_tide_h      = './inputs/tpxo7.2/h_tpxo7.2.nc'

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -482,7 +482,7 @@ class Extract:
         sc_time = self.sc_time
         sc_z_len = self.sc_z_len
         # define src/dst cals
-        if self.settings["time_interpolation"] is False:
+        if self.settings.get("time_interpolation", True) is False:
             # Source calender
             self.S_cal = utime(sc_time.units, sc_time.calendar)
             # First second of the target month
@@ -919,7 +919,7 @@ class Extract:
                     entry = self.d_bdy[self.var_nam[vn + 1]][year]
                 else:
                     entry = self.d_bdy[self.var_nam[vn]][year]
-                if entry["data"] is None or self.settings["time_interpolation"] is False:
+                if entry["data"] is None or self.settings.get("time_interpolation", True) is False:
                     # Create entry with singleton 3rd dimension
                     entry["data"] = np.array([data_out])
                 else:

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -482,43 +482,57 @@ class Extract:
         sc_time = self.sc_time
         sc_z_len = self.sc_z_len
         # define src/dst cals
-        sf, ed = self.cal_trans(
-            sc_time.calendar,  # sc_time[0].calendar
-            self.settings["dst_calendar"],
-            year,
-            month,
-        )
-        DstCal = utime("seconds since %d-1-1" % year, self.settings["dst_calendar"])
-        dst_start = DstCal.date2num(datetime(year, month, 1))
-        dst_end = DstCal.date2num(datetime(year, month, ed, 23, 59, 59))
-
-        self.S_cal = utime(
-            sc_time.units, sc_time.calendar
-        )  # sc_time[0].units,sc_time[0].calendar)
-
-        self.D_cal = utime(
-            "seconds since %d-1-1" % self.settings["base_year"],
-            self.settings["dst_calendar"],
-        )
-
-        src_date_seconds = np.zeros(len(sc_time.time_counter))
-        for index in range(len(sc_time.time_counter)):
-            tmp_date = self.S_cal.num2date(sc_time.time_counter[index])
-            src_date_seconds[index] = DstCal.date2num(tmp_date) * sf
-
-        # Get first and last date within range, init to cover entire range
-        first_date = 0
-        last_date = len(sc_time.time_counter) - 1
-        rev_seq = list(range(len(sc_time.time_counter)))
-        rev_seq.reverse()
-        for date in rev_seq:
-            if src_date_seconds[date] < dst_start:
-                first_date = date
-                break
-        for date in range(len(sc_time.time_counter)):
-            if src_date_seconds[date] > dst_end:
-                last_date = date
-                break
+        if self.settings["time_interpolation"] is False:
+            # Source calender
+            self.S_cal = utime(sc_time.units, sc_time.calendar)
+            # First second of the target month
+            target_time   = self.S_cal.date2num( datetime(year, month, 1) )
+            # Find index in source time counter for target year and month
+            closest_time_ind = min( ind for ind, item in enumerate(sc_time.time_counter) if item >= target_time )
+            # This is index for first and last date
+            first_date = closest_time_ind
+            last_date = first_date
+            self.logger.info( "matched month: " + str( self.S_cal.num2date(sc_time.time_counter[last_date]) ) )
+            # Set time counter for output as array
+            self.time_counter = sc_time.time_counter[last_date:last_date+1]
+        else:
+            sf, ed = self.cal_trans(
+                sc_time.calendar,  # sc_time[0].calendar
+                self.settings["dst_calendar"],
+                year,
+                month,
+            )
+            DstCal = utime("seconds since %d-1-1" % year, self.settings["dst_calendar"])
+            dst_start = DstCal.date2num(datetime(year, month, 1))
+            dst_end = DstCal.date2num(datetime(year, month, ed, 23, 59, 59))
+    
+            self.S_cal = utime(
+                sc_time.units, sc_time.calendar
+            )  # sc_time[0].units,sc_time[0].calendar)
+    
+            self.D_cal = utime(
+                "seconds since %d-1-1" % self.settings["base_year"],
+                self.settings["dst_calendar"],
+            )
+    
+            src_date_seconds = np.zeros(len(sc_time.time_counter))
+            for index in range(len(sc_time.time_counter)):
+                tmp_date = self.S_cal.num2date(sc_time.time_counter[index])
+                src_date_seconds[index] = DstCal.date2num(tmp_date) * sf
+    
+            # Get first and last date within range, init to cover entire range
+            first_date = 0
+            last_date = len(sc_time.time_counter) - 1
+            rev_seq = list(range(len(sc_time.time_counter)))
+            rev_seq.reverse()
+            for date in rev_seq:
+                if src_date_seconds[date] < dst_start:
+                    first_date = date
+                    break
+            for date in range(len(sc_time.time_counter)):
+                if src_date_seconds[date] > dst_end:
+                    last_date = date
+                    break
 
         self.logger.info("first/last dates: %s %s", first_date, last_date)
 
@@ -905,7 +919,7 @@ class Extract:
                     entry = self.d_bdy[self.var_nam[vn + 1]][year]
                 else:
                     entry = self.d_bdy[self.var_nam[vn]][year]
-                if entry["data"] is None:
+                if entry["data"] is None or self.settings["time_interpolation"] is False:
                     # Create entry with singleton 3rd dimension
                     entry["data"] = np.array([data_out])
                 else:

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -486,15 +486,22 @@ class Extract:
             # Source calender
             self.S_cal = utime(sc_time.units, sc_time.calendar)
             # First second of the target month
-            target_time   = self.S_cal.date2num( datetime(year, month, 1) )
+            target_time = self.S_cal.date2num(datetime(year, month, 1))
             # Find index in source time counter for target year and month
-            closest_time_ind = min( ind for ind, item in enumerate(sc_time.time_counter) if item >= target_time )
+            closest_time_ind = min(
+                ind
+                for ind, item in enumerate(sc_time.time_counter)
+                if item >= target_time
+            )
             # This is index for first and last date
             first_date = closest_time_ind
             last_date = first_date
-            self.logger.info( "matched month: " + str( self.S_cal.num2date(sc_time.time_counter[last_date]) ) )
+            self.logger.info(
+                "matched month: "
+                + str(self.S_cal.num2date(sc_time.time_counter[last_date]))
+            )
             # Set time counter for output as array
-            self.time_counter = sc_time.time_counter[last_date:last_date+1]
+            self.time_counter = sc_time.time_counter[last_date : last_date + 1]
         else:
             sf, ed = self.cal_trans(
                 sc_time.calendar,  # sc_time[0].calendar
@@ -505,21 +512,21 @@ class Extract:
             DstCal = utime("seconds since %d-1-1" % year, self.settings["dst_calendar"])
             dst_start = DstCal.date2num(datetime(year, month, 1))
             dst_end = DstCal.date2num(datetime(year, month, ed, 23, 59, 59))
-    
+
             self.S_cal = utime(
                 sc_time.units, sc_time.calendar
             )  # sc_time[0].units,sc_time[0].calendar)
-    
+
             self.D_cal = utime(
                 "seconds since %d-1-1" % self.settings["base_year"],
                 self.settings["dst_calendar"],
             )
-    
+
             src_date_seconds = np.zeros(len(sc_time.time_counter))
             for index in range(len(sc_time.time_counter)):
                 tmp_date = self.S_cal.num2date(sc_time.time_counter[index])
                 src_date_seconds[index] = DstCal.date2num(tmp_date) * sf
-    
+
             # Get first and last date within range, init to cover entire range
             first_date = 0
             last_date = len(sc_time.time_counter) - 1
@@ -919,7 +926,10 @@ class Extract:
                     entry = self.d_bdy[self.var_nam[vn + 1]][year]
                 else:
                     entry = self.d_bdy[self.var_nam[vn]][year]
-                if entry["data"] is None or self.settings.get("time_interpolation", True) is False:
+                if (
+                    entry["data"] is None
+                    or self.settings.get("time_interpolation", True) is False
+                ):
                     # Create entry with singleton 3rd dimension
                     entry["data"] = np.array([data_out])
                 else:

--- a/src/pybdy/nemo_bdy_ncgen.py
+++ b/src/pybdy/nemo_bdy_ncgen.py
@@ -34,7 +34,7 @@ def CreateBDYNetcdfFile(
     ncid.createDimension("time_counter", None)
 
     # define variable
-    vartcID = ncid.createVariable("time_counter", "f4", ("time_counter",))
+    vartcID = ncid.createVariable("time_counter", "f8", ("time_counter",))
     varlonID = ncid.createVariable(
         "nav_lon",
         "f4",

--- a/src/pybdy/nemo_bdy_setup.py
+++ b/src/pybdy/nemo_bdy_setup.py
@@ -322,7 +322,7 @@ def _assign(data):
     for line in data:
         keyvalue = line.split("=", 1)
         _get_val(vars_dictionary, bool_vars_dictionary, keyvalue)
-        
+
     return vars_dictionary, bool_vars_dictionary
 
 

--- a/src/pybdy/nemo_bdy_setup.py
+++ b/src/pybdy/nemo_bdy_setup.py
@@ -322,6 +322,7 @@ def _assign(data):
     for line in data:
         keyvalue = line.split("=", 1)
         _get_val(vars_dictionary, bool_vars_dictionary, keyvalue)
+        
     return vars_dictionary, bool_vars_dictionary
 
 

--- a/src/pybdy/profiler.py
+++ b/src/pybdy/profiler.py
@@ -252,7 +252,7 @@ def process_bdy(setup_filepath=0, mask_gui=False):
     yrs = list(range(yr_000, yr_end + 1))
 
     if yr_end - yr_000 >= 1:
-        if list(range(mn_000, mn_end + 1)) < 12:
+        if mn_end - mn_000 < 12:
             logger.info(
                 "Warning: All months will be extracted as the number "
                 + "of years is greater than 1"
@@ -341,7 +341,7 @@ def process_bdy(setup_filepath=0, mask_gui=False):
 
                 # Interpolate/stretch in time if time frequecy is not a factor
                 # of a month and/or parent:child calendars differ
-                if settings["time_interpolation"]:
+                if settings.get("time_interpolation", True):
                     logger.info("Applying temporal interpolation from parent to child.")
                     extract_obj[key].time_interp(year, month)
                 else:

--- a/src/pybdy/profiler.py
+++ b/src/pybdy/profiler.py
@@ -337,16 +337,17 @@ def process_bdy(setup_filepath=0, mask_gui=False):
         for month in mns:
             for key, val in list(emap.items()):
                 # Extract the data for a given month and year
-
                 extract_obj[key].extract_month(year, month)
 
                 # Interpolate/stretch in time if time frequecy is not a factor
                 # of a month and/or parent:child calendars differ
-
-                extract_obj[key].time_interp(year, month)
+                if settings["time_interpolation"]:
+                    logger.info("Applying temporal interpolation from parent to child.")
+                    extract_obj[key].time_interp(year, month)
+                else:
+                    logger.info("Temporal interpolation not applied.")
 
                 # Finally write to file
-
                 extract_obj[key].write_out(year, month, bdy_ind[key], unit_origin)
 
     logger.info("End NRCT Logging: " + time.asctime())


### PR DESCRIPTION
close #124 

Enhancement use case: User has a parent with monthly fields for T,U,V grids and wants to generate boundary conditions that are also monthly (allowing NEMO to interpolate onto the model time step).

Current behaviour: pyBdy will take monthly inputs and interpolate to produce daily boundary files.

New behaviour: A boolean option has been added to the namelist called ln_time_interpolation. If this option is set to true or omitted then behaviour will continue as before. If it is set to false then the boundary files generated will use the source calendar to create the monthly boundary files.

Limitations: This is currently only set up to work with input files that are monthly. 

Testing: Tested on benchmark and also creating multiple years worth of monthly boundary files for T,U,V (2d+3d) from GO8->AMM7

Other things: I found I needed to change the time_counter output type from f4 to f8 , in profiler.py line 255 there is a typo bug that was erroring when trying to run over multiple years. Given what you said in the meeting you might want to double check this, it seems to just be some logic to send info to the logger.