### PR TITLE
issue 127, a fix for the temp and salinity interpolation issues

### DIFF
--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -873,13 +873,19 @@ class Extract:
                 else:
                     id_121 = self.id_121_3d
                     tmp_filt = self.tmp_filt_3d
-
-                tmp_valid = np.invert(np.isnan(dst_bdy.flatten("F")[id_121]))
-
+                 
+                #tmp_valid = np.invert(np.isnan(dst_bdy.flatten("F")[id_121]))
+                # interpolation points that are not wet (=0) need to be reflected
+                # in the denominator
+                tmp_valid = np.invert(dst_bdy.flatten('F')[id_121] == 0 )
+                # raises invalid divide error when all points are dry,
+                # this is ok because the numerator=0 as well so it will
+                # set to NaN which is set to zero later in code
+                np.seterr(invalid='ignore')
                 dst_bdy = np.nansum(
                     dst_bdy.flatten("F")[id_121] * tmp_filt, 2
                 ) / np.sum(tmp_filt * tmp_valid, 2)
-
+                np.seterr(invalid='warn')
                 # Finished first run operations
                 # self.first = False
 
@@ -890,6 +896,7 @@ class Extract:
                     np.nanmax(dst_bdy),
                 )
                 dst_bdy[nan_ind] = 0
+
                 self.logger.info(
                     " post dst_bdy %s %s", np.nanmin(dst_bdy), np.nanmax(dst_bdy)
                 )


### PR DESCRIPTION
This should fix the error in the temperature and salinity fields in the near bottom grid cells described in #127.

The issue seems to be that horizontal interpolation was incorrectly handling non-wet points in the source file (assuming they are NaNs rather than zeros). This meant that close to the bed the denominator in mean calculation did not account for the fact that fewer points are used in the interpolation.

Thanks to @swakelin for identifying this.

Testing:

Previous behaviour:
The bdy data I generated from GO8 caused AMM7 to become unstable because of the spurious values near the bottom of the water column (I think this effects the velocities as well).

New behaviour:
I have regenerated the bdy files and now AMM7 runs are stable. 

Closes #127 