### PR TITLE
#189 Fixed the holding array dimension bug

### DIFF
--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -635,7 +635,7 @@ class Extract:
                     hold = np.zeros((((last_date + 1) - first_date), 1, self.num_bdy))
                 else:
                     hold = np.zeros(
-                        (((last_date + 1) - first_date), sc_z_len, self.num_bdy)
+                        (((last_date + 1) - first_date), len(self.dst_z), self.num_bdy)
                     )
 
                 if self.key_vec is True and self.rot_dir == "j":


### PR DESCRIPTION
Fixed #189. The problem was with the destination array being initialised with the number of levels in the source.
I made an example benchmark destination grid with 71 levels instead of 75 to test that the bug was present in the master and not in this fix.