### PR TITLE
196 bdy wrap

### DIFF
--- a/src/pybdy/nemo_bdy_extr_assist.py
+++ b/src/pybdy/nemo_bdy_extr_assist.py
@@ -74,7 +74,39 @@ def get_ind(dst_lon, dst_lat, sc_lon, sc_lat):
     jmin = np.maximum(np.amin(sub_j), 0)
     jmax = np.minimum(np.amax(sub_j), len(sc_lon[:, 0]) - 1) + 1
 
+    import matplotlib.pyplot as plt
+
+    plt.scatter(sc_lon, sc_lat, c="b")
+    plt.scatter(sc_lon[jmin:jmax, imin:imax], sc_lat[jmin:jmax, imin:imax], c="r")
+    plt.show()
     return imin, imax, jmin, jmax
+
+
+def check_wrap(imin, imax, sc_lon):
+    """
+    Check if source domain wraps and dst spans the wrap.
+
+    Parameters
+    ----------
+    imin (int) : minimum i index
+    imax (int) : maximum i index
+    sc_lon (np.array)  : the longitude of the source grid
+
+    Returns
+    -------
+    wrap_flag (bool) :  if true the sc wraps and dst spans wrap
+    """
+    dx = sc_lon[:, -1] - sc_lon[:, -2]
+    lon_next = sc_lon[:, -1] + dx
+    lon_next[lon_next > 180] -= 360
+
+    # check if last lon is closer to first lon than the grid spacing
+    sc_wrap = np.isclose(lon_next, sc_lon[:, 0], atol=dx / 2).any()
+
+    # check if dst touches either sc i-edge
+    dst_spans = (imin == 0) | (imax == sc_lon.shape[1])
+    wrap_flag = sc_wrap & dst_spans
+    return wrap_flag
 
 
 def get_vertical_weights(dst_dep, dst_len_z, num_bdy, sc_z, sc_z_len, ind, zco):

--- a/src/pybdy/nemo_bdy_extr_assist.py
+++ b/src/pybdy/nemo_bdy_extr_assist.py
@@ -101,7 +101,12 @@ def check_wrap(imin, imax, sc_lon):
     # check if dst touches either sc i-edge
     dst_spans = (imin == 0) | (imax == sc_lon.shape[1])
     wrap_flag = sc_wrap & dst_spans
-    return wrap_flag
+
+    if wrap_flag:
+        # make sure imin and imax take the whole x dim
+        imin = 0
+        imax = sc_lon.shape[1]
+    return wrap_flag, imin, imax
 
 
 def get_vertical_weights(dst_dep, dst_len_z, num_bdy, sc_z, sc_z_len, ind, zco):

--- a/src/pybdy/nemo_bdy_extr_assist.py
+++ b/src/pybdy/nemo_bdy_extr_assist.py
@@ -48,9 +48,13 @@ def get_ind(dst_lon, dst_lat, sc_lon, sc_lat):
     """
     ind_e = sc_lon < np.amax(dst_lon)
     ind_w = sc_lon > np.amin(dst_lon)
+    ind_e[:, 2:] = ind_e[:, :-2]
+    ind_w[:, :-2] = ind_w[:, 2:]
     ind_ew = np.logical_and(ind_e, ind_w)
     ind_s = sc_lat > np.amin(dst_lat)
     ind_n = sc_lat < np.amax(dst_lat)
+    ind_s[:-2, :] = ind_s[2:, :]
+    ind_n[2:, :] = ind_n[:-2, :]
     ind_sn = np.logical_and(ind_s, ind_n)
 
     ind = np.where(np.logical_and(ind_ew, ind_sn) != 0)
@@ -65,10 +69,10 @@ def get_ind(dst_lon, dst_lat, sc_lon, sc_lat):
             "The destination grid lat, lon is not inside the source grid lat, lon."
         )
 
-    imin = np.maximum(np.amin(sub_i) - 2, 0)
-    imax = np.minimum(np.amax(sub_i) + 2, len(sc_lon[0, :]) - 1) + 1
-    jmin = np.maximum(np.amin(sub_j) - 2, 0)
-    jmax = np.minimum(np.amax(sub_j) + 2, len(sc_lon[:, 0]) - 1) + 1
+    imin = np.maximum(np.amin(sub_i), 0)
+    imax = np.minimum(np.amax(sub_i), len(sc_lon[0, :]) - 1) + 1
+    jmin = np.maximum(np.amin(sub_j), 0)
+    jmax = np.minimum(np.amax(sub_j), len(sc_lon[:, 0]) - 1) + 1
 
     return imin, imax, jmin, jmax
 

--- a/src/pybdy/nemo_bdy_extr_assist.py
+++ b/src/pybdy/nemo_bdy_extr_assist.py
@@ -74,11 +74,6 @@ def get_ind(dst_lon, dst_lat, sc_lon, sc_lat):
     jmin = np.maximum(np.amin(sub_j), 0)
     jmax = np.minimum(np.amax(sub_j), len(sc_lon[:, 0]) - 1) + 1
 
-    import matplotlib.pyplot as plt
-
-    plt.scatter(sc_lon, sc_lat, c="b")
-    plt.scatter(sc_lon[jmin:jmax, imin:imax], sc_lat[jmin:jmax, imin:imax], c="r")
-    plt.show()
     return imin, imax, jmin, jmax
 
 

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -201,6 +201,7 @@ class Extract:
             imin, imax, jmin, jmax = extr_assist.get_ind(
                 dst_lon_ch, dst_lat_ch, SC.lon, SC.lat
             )
+
             # Summarise subset region
 
             self.logger.info("Extract __init__: subset region limits")
@@ -286,7 +287,23 @@ class Extract:
             i_sp = np.vstack((i_sp, i_sp, i_sp))
             i_sp = np.vstack((i_sp, i_sp + 1, i_sp - 1))
 
-            # Index out of bounds error check not implemented
+            # Check index out of bounds
+            if (i_sp >= source_dims[1]).any() | (i_sp < 0).any():
+                wrap_flag = extr_assist.check_wrap(imin, imax, SC.lon)
+                if wrap_flag:
+                    # If wrap_flag is true make indices wrap
+                    i_sp[i_sp >= source_dims[1]] -= source_dims[1]
+                    i_sp[i_sp < 0] += source_dims[1]
+                else:
+                    raise Exception(
+                        "Destination touches source i-edge but source is not cylindrical"
+                    )
+
+            if (j_sp >= source_dims[0]).any() | (j_sp < 0).any():
+                # North Fold not implemented yet
+                raise Exception(
+                    "Destination touches source j-edge but North Fold is not implemented"
+                )
 
             # Determine 9 nearest neighbours based on distance
             ind = sub2ind(source_dims, i_sp, j_sp)

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -668,6 +668,9 @@ class Extract:
                     np.min(j_run) : np.max(j_run) + 1,
                     np.min(i_run) : np.max(i_run) + i_plus,
                 ]
+                if t_mask.shape[1] == 1:
+                    t_mask = np.tile(t_mask, (1, sc_z_len, 1, 1))
+
                 if self.key_vec:
                     varid_3 = nc_3["umask"]
                     u_mask = varid_3[
@@ -683,6 +686,10 @@ class Extract:
                         np.min(extended_j) : np.max(extended_j) + 1,
                         np.min(i_run) : np.max(i_run) + i_plus,
                     ]
+                    if t_mask.shape[1] == 1:
+                        u_mask = np.tile(u_mask, (1, sc_z_len, 1, 1))
+                    if t_mask.shape[1] == 1:
+                        v_mask = np.tile(v_mask, (1, sc_z_len, 1, 1))
                 nc_3.close()
 
                 if self.sc_wrap[chk]:
@@ -807,7 +814,7 @@ class Extract:
                         np.nanmin(sc_array[0]),
                         np.nanmax(sc_array[0]),
                     )
-                    print(sc_z_len, sc_array[0].shape, t_mask.shape)
+
                     if isslab and not self.key_vec:
                         sc_array[0][t_mask[:, 0:1, :, :] == 0] = np.NaN
                     else:

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -167,6 +167,7 @@ class Extract:
         all_chunk = np.unique(chunk_number)
 
         sc_ind_ch = []
+        self.sc_wrap = np.zeros((len(all_chunk)), dtype=bool)
         self.dst_chunk = chunk_number.copy()
         self.dist_tot = np.zeros((len(dst_lon), 9))
         self.num_bdy_ch = np.zeros((len(all_chunk)), dtype=int)
@@ -201,6 +202,7 @@ class Extract:
             imin, imax, jmin, jmax = extr_assist.get_ind(
                 dst_lon_ch, dst_lat_ch, SC.lon, SC.lat
             )
+            wrap_flag, imin, imax = extr_assist.check_wrap(imin, imax, SC.lon)
 
             # Summarise subset region
 
@@ -289,7 +291,6 @@ class Extract:
 
             # Check index out of bounds
             if (i_sp >= source_dims[1]).any() | (i_sp < 0).any():
-                wrap_flag = extr_assist.check_wrap(imin, imax, SC.lon)
                 if wrap_flag:
                     # If wrap_flag is true make indices wrap over east-west fold
                     i_sp[i_sp >= source_dims[1]] -= source_dims[1]
@@ -463,6 +464,7 @@ class Extract:
             # Put variables in list and array
 
             sc_ind_ch.append(sc_ind)
+            self.sc_wrap[c] = wrap_flag
             self.dist_tot[chunk, :] = dist_tot
             self.tmp_filt_2d[:, chunk, :] = tmp_filt_2d
             self.tmp_filt_3d[:, chunk, :] = tmp_filt_3d
@@ -646,6 +648,14 @@ class Extract:
             extended_j = np.arange(
                 self.sc_ind_ch[chk]["jmin"] - 1, self.sc_ind_ch[chk]["jmax"]
             )
+            if self.sc_wrap[chk]:
+                # If wrap_flag is true make indices wrap over east-west fold
+                # imax is already adjusted to x dim max if wrapped
+                extended_i[extended_i < 0] += self.sc_ind_ch[chk]["imax"]
+                i_plus = 0
+            else:
+                i_plus = 1
+
             ind = self.sc_ind_ch[chk]["ind"]
 
             if self.first:
@@ -656,7 +666,7 @@ class Extract:
                     :1,
                     :sc_z_len,
                     np.min(j_run) : np.max(j_run) + 1,
-                    np.min(i_run) : np.max(i_run) + 1,
+                    np.min(i_run) : np.max(i_run) + i_plus,
                 ]
                 if self.key_vec:
                     varid_3 = nc_3["umask"]
@@ -664,16 +674,26 @@ class Extract:
                         :1,
                         :sc_z_len,
                         np.min(j_run) : np.max(j_run) + 1,
-                        np.min(extended_i) : np.max(extended_i) + 1,
+                        np.min(extended_i) : np.max(extended_i) + i_plus,
                     ]
                     varid_3 = nc_3["vmask"]
                     v_mask = varid_3[
                         :1,
                         :sc_z_len,
                         np.min(extended_j) : np.max(extended_j) + 1,
-                        np.min(i_run) : np.max(i_run) + 1,
+                        np.min(i_run) : np.max(i_run) + i_plus,
                     ]
                 nc_3.close()
+
+                if self.sc_wrap[chk]:
+                    # Stick first and last slice on opposite end
+                    t_mask = np.concatenate((t_mask, t_mask[:, :, :, 0:1]), axis=3)
+                    if self.key_vec:
+                        u_mask = np.concatenate(
+                            (u_mask[:, :, :, -2:-1], u_mask, u_mask[:, :, :, 0:1]),
+                            axis=3,
+                        )
+                        v_mask = np.concatenate((v_mask, v_mask[:, :, :, 0:1]), axis=3)
 
             # Loop over identified files
             for f in range(first_date, last_date + 1):
@@ -719,7 +739,7 @@ class Extract:
                             f : f + 1,
                             :sc_z_len,
                             np.min(j_run) : np.max(j_run) + 1,
-                            np.min(i_run) : np.max(i_run) + 1,
+                            np.min(i_run) : np.max(i_run) + i_plus,
                         ]
                     # Extract 3D vector variables
                     elif self.key_vec:
@@ -728,14 +748,14 @@ class Extract:
                             f : f + 1,
                             :sc_z_len,
                             np.min(j_run) : np.max(j_run) + 1,
-                            np.min(extended_i) : np.max(extended_i) + 1,
+                            np.min(extended_i) : np.max(extended_i) + i_plus,
                         ]
                         # For v vels take j-1
                         sc_alt_arr[1] = varid_2[
                             f : f + 1,
                             :sc_z_len,
                             np.min(extended_j) : np.max(extended_j) + 1,
-                            np.min(i_run) : np.max(i_run) + 1,
+                            np.min(i_run) : np.max(i_run) + i_plus,
                         ]
                     # Extract 2D scalar vars
                     else:
@@ -743,8 +763,27 @@ class Extract:
                         sc_array[0] = varid[
                             f : f + 1,
                             np.min(j_run) : np.max(j_run) + 1,
-                            np.min(i_run) : np.max(i_run) + 1,
-                        ].reshape([1, 1, j_run.size, i_run.size])
+                            np.min(i_run) : np.max(i_run) + i_plus,
+                        ][:, np.newaxis, :, :]
+
+                    if self.sc_wrap[chk]:
+                        # Stick first and last slice on opposite end
+                        if self.key_vec:
+                            sc_alt_arr[0] = np.concatenate(
+                                (
+                                    sc_alt_arr[0][:, :, :, -2:-1],
+                                    sc_alt_arr[0],
+                                    sc_alt_arr[0][:, :, :, 0:1],
+                                ),
+                                axis=3,
+                            )
+                            sc_alt_arr[1] = np.concatenate(
+                                (sc_alt_arr[1], sc_alt_arr[1][:, :, :, 0:1]), axis=3
+                            )
+                        else:
+                            sc_array[0] = np.concatenate(
+                                (sc_array[0], sc_array[0][:, :, :, 0:1]), axis=3
+                            )
 
                     # Average vector vars onto T-grid
                     if self.key_vec:
@@ -768,7 +807,7 @@ class Extract:
                         np.nanmin(sc_array[0]),
                         np.nanmax(sc_array[0]),
                     )
-
+                    print(sc_z_len, sc_array[0].shape, t_mask.shape)
                     if isslab and not self.key_vec:
                         sc_array[0][t_mask[:, 0:1, :, :] == 0] = np.NaN
                     else:

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -672,8 +672,8 @@ class Extract:
                     raise Exception(
                         "Mask dimensions are not correct. Depth is "
                         + str(sc_z_len)
-                        + " but tmask is shape "
-                        + str(t_mask.shape)
+                        + " but tmask is "
+                        + str(t_mask.shape[1])
                     )
 
                 if self.key_vec:
@@ -695,15 +695,15 @@ class Extract:
                         raise Exception(
                             "Mask dimensions are not correct. Depth is "
                             + str(sc_z_len)
-                            + " but umask is shape "
-                            + str(u_mask.shape)
+                            + " but umask is "
+                            + str(u_mask.shape[1])
                         )
                     if v_mask.shape[1] == 1:
                         raise Exception(
                             "Mask dimensions are not correct. Depth is "
                             + str(sc_z_len)
-                            + " but vmask is shape "
-                            + str(v_mask.shape)
+                            + " but vmask is "
+                            + str(v_mask.shape[1])
                         )
                 nc_3.close()
 

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -669,7 +669,12 @@ class Extract:
                     np.min(i_run) : np.max(i_run) + i_plus,
                 ]
                 if t_mask.shape[1] == 1:
-                    t_mask = np.tile(t_mask, (1, sc_z_len, 1, 1))
+                    raise Exception(
+                        "Mask dimensions are not correct. Depth is "
+                        + str(sc_z_len)
+                        + " but tmask is shape "
+                        + str(t_mask.shape)
+                    )
 
                 if self.key_vec:
                     varid_3 = nc_3["umask"]
@@ -686,10 +691,20 @@ class Extract:
                         np.min(extended_j) : np.max(extended_j) + 1,
                         np.min(i_run) : np.max(i_run) + i_plus,
                     ]
-                    if t_mask.shape[1] == 1:
-                        u_mask = np.tile(u_mask, (1, sc_z_len, 1, 1))
-                    if t_mask.shape[1] == 1:
-                        v_mask = np.tile(v_mask, (1, sc_z_len, 1, 1))
+                    if u_mask.shape[1] == 1:
+                        raise Exception(
+                            "Mask dimensions are not correct. Depth is "
+                            + str(sc_z_len)
+                            + " but umask is shape "
+                            + str(u_mask.shape)
+                        )
+                    if v_mask.shape[1] == 1:
+                        raise Exception(
+                            "Mask dimensions are not correct. Depth is "
+                            + str(sc_z_len)
+                            + " but vmask is shape "
+                            + str(v_mask.shape)
+                        )
                 nc_3.close()
 
                 if self.sc_wrap[chk]:

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -291,7 +291,7 @@ class Extract:
             if (i_sp >= source_dims[1]).any() | (i_sp < 0).any():
                 wrap_flag = extr_assist.check_wrap(imin, imax, SC.lon)
                 if wrap_flag:
-                    # If wrap_flag is true make indices wrap
+                    # If wrap_flag is true make indices wrap over east-west fold
                     i_sp[i_sp >= source_dims[1]] -= source_dims[1]
                     i_sp[i_sp < 0] += source_dims[1]
                 else:

--- a/tests/test_zz_end_to_end.py
+++ b/tests/test_zz_end_to_end.py
@@ -278,13 +278,95 @@ def test_sco_zco():
     assert summary_grid == test_grid, "May need to update regression values."
 
 
-def generate_sc_test_case(zco):
+def test_wrap_sc():
+    """
+    Test the full pybdy processing for dst that spans a warpped sc domain.
+
+    This test is for dst in zco and sc in zco vertical coordinates.
+    Horizontal coordinates are A-Grid.
+    sc data wraps at 0 degrees longitude
+    """
+    path1, path2, path3 = generate_sc_test_case(zco=True, wrap=1)
+    path4 = generate_dst_test_case(zco=True)
+    name_list_path = modify_namelist(path1, path3, path4)
+
+    # Run pybdy
+    subprocess.run(
+        "pybdy -s " + name_list_path,
+        shell=True,
+        check=True,
+        text=True,
+    )
+
+    coords = "./tests/data/coordinates.bdy.nc"
+    output_t = "./tests/data/data_output_bdyT_y1979m11.nc"
+    output_u = "./tests/data/data_output_bdyU_y1979m11.nc"
+    output_v = "./tests/data/data_output_bdyV_y1979m11.nc"
+
+    # Check output
+    ds_c = xr.open_dataset(coords)
+    ds_t = xr.open_dataset(output_t)
+    ds_u = xr.open_dataset(output_u)
+    ds_v = xr.open_dataset(output_v)
+    temp = ds_t["votemper"].to_masked_array()
+
+    summary_grid = {
+        "Num_var_co": len(ds_c.keys()),
+        "Num_var_t": len(ds_t.keys()),
+        "Min_gdept": float(ds_t["gdept"].min().to_numpy()),
+        "Max_gdept": float(ds_t["gdept"].max().to_numpy()),
+        "Shape_temp": ds_t["votemper"].shape,
+        "Shape_ssh": ds_t["sossheig"].shape,
+        "Shape_mask": ds_t["bdy_msk"].shape,
+        "Mean_temp": float(ds_t["votemper"].mean().to_numpy()),
+        "Mean_sal": float(ds_t["vosaline"].mean().to_numpy()),
+        "Sum_unmask": np.ma.count(temp),
+        "Sum_mask": np.ma.count_masked(temp),
+        "Shape_u": ds_u["vozocrtx"].shape,
+        "Shape_v": ds_v["vomecrty"].shape,
+        "Mean_u": float(ds_u["vozocrtx"].mean().to_numpy()),
+        "Mean_v": float(ds_v["vomecrty"].mean().to_numpy()),
+    }
+
+    # Clean up files
+    os.remove(path1)
+    os.remove(path2)
+    os.remove(path4)
+    os.remove(coords)
+    os.remove(output_t)
+    os.remove(output_u)
+    os.remove(output_v)
+
+    print(summary_grid)
+    test_grid = {
+        "Num_var_co": 21,
+        "Num_var_t": 11,
+        "Min_gdept": 41.66666793823242,
+        "Max_gdept": 1041.6666259765625,
+        "Shape_temp": (30, 25, 1, 1584),
+        "Shape_ssh": (30, 1, 1584),
+        "Shape_mask": (60, 50),
+        "Mean_temp": 16.437015533447266,
+        "Mean_sal": 30.8212833404541,
+        "Sum_unmask": 495030,
+        "Sum_mask": 692970,
+        "Shape_u": (30, 25, 1, 1566),
+        "Shape_v": (30, 25, 1, 1566),
+        "Mean_u": 0.9023050665855408,
+        "Mean_v": 0.8996582627296448,
+    }
+
+    assert summary_grid == test_grid, "May need to update regression values."
+
+
+def generate_sc_test_case(zco, wrap=0):
     """
     Generate a synthetic test case for source.
 
     Parameters
     ----------
     zco (bool) : if true generate zco vertical coordinates, if false sco
+    wrap (bool): if true lons wrap in the middle of dst
 
     Returns
     -------
@@ -300,14 +382,27 @@ def generate_sc_test_case(zco):
 
     dx = 0.5
     dy = 0.25
-    lon_t = np.arange(-20, 8, dx)
-    lat_t = np.arange(39, 56, dy)
+    if wrap:
+        dx = 1
+        lon_t = np.arange(0, 360, dx)
+        lat_t = np.arange(39, 56, dy)
+    else:
+        lon_t = np.arange(-20, 8, dx)
+        lat_t = np.arange(39, 56, dy)
     ppe1 = np.zeros((len(lon_t))) + dx
     ppe2 = np.zeros((len(lat_t))) + dy
 
     # Generate an A-Grid
     synth = synth_bathymetry.Bathymetry(ppe1, ppe2, ppglam0=lon_t[0], ppgphi0=lat_t[0])
     synth = synth.sea_mount(depth=1000, stiff=1)
+
+    if wrap:
+        # make lon -180 to 180 but wrap at 0
+        lon_var = ["glamt", "glamu", "glamv", "glamf", "nav_lon"]
+        for v in lon_var:
+            synth_glamt = np.array(synth[v].to_numpy())
+            synth_glamt[synth_glamt > 180] -= 360
+            synth[v] = xr.DataArray(synth_glamt, dims=["y", "x"], name=v)
 
     # These are garbage let grid.hgr calculate them
     synth = synth.drop_vars(["e1t", "e2t", "e1v", "e2v", "e1u", "e2u", "e1f", "e2f"])

--- a/tests/test_zz_end_to_end.py
+++ b/tests/test_zz_end_to_end.py
@@ -326,6 +326,8 @@ def test_wrap_sc():
         "Shape_v": ds_v["vomecrty"].shape,
         "Mean_u": float(ds_u["vozocrtx"].mean().to_numpy()),
         "Mean_v": float(ds_v["vomecrty"].mean().to_numpy()),
+        "Temp_Strip1": ds_t["votemper"].to_numpy()[0, 0, 0, 123:127].tolist(),
+        "Temp_Strip2": ds_t["votemper"].to_numpy()[0, 0, 0, 1439:1441].tolist(),
     }
 
     # Clean up files
@@ -346,14 +348,21 @@ def test_wrap_sc():
         "Shape_temp": (30, 25, 1, 1584),
         "Shape_ssh": (30, 1, 1584),
         "Shape_mask": (60, 50),
-        "Mean_temp": 16.437015533447266,
-        "Mean_sal": 30.8212833404541,
+        "Mean_temp": 17.540178298950195,
+        "Mean_sal": 30.812232971191406,
         "Sum_unmask": 495030,
         "Sum_mask": 692970,
         "Shape_u": (30, 25, 1, 1566),
         "Shape_v": (30, 25, 1, 1566),
-        "Mean_u": 0.9023050665855408,
-        "Mean_v": 0.8996582627296448,
+        "Mean_u": 0.9030880331993103,
+        "Mean_v": 0.9035892486572266,
+        "Temp_Strip1": [
+            19.80881690979004,
+            24.904409408569336,
+            24.904409408569336,
+            30.0,
+        ],
+        "Temp_Strip2": [30.0, 19.80881690979004],
     }
 
     assert summary_grid == test_grid, "May need to update regression values."
@@ -465,6 +474,12 @@ def generate_sc_test_case(zco, wrap=0):
     depth = depth.transpose("time_counter", "z", "y", "x")
 
     data_vars["votemper"] = synth_temp_sal.temperature_profile(depth)
+    if wrap:
+        temp = np.array(data_vars["votemper"].to_numpy())
+        temp[:, :, :, 0] = 30
+        data_vars["votemper"] = xr.DataArray(
+            temp, dims=["time_counter", "z", "y", "x"], name="votemper"
+        ).copy()
     data_vars["vosaline"] = synth_temp_sal.salinity_profile(depth)
     uvel = np.ones_like(data_vars["vozocrtx"])
     uvel[:, -10:, :, :] = 0.5


### PR DESCRIPTION
This branch fixes #196, the issue where destination bdy points that spanned over the east-west fold in global source data had out of bound index errors.

The code is now able to identify when the dst will touch the i-egde and if the sc is a domain that wraps over the fold. It can then adjust indices to account for the fold and extends the sc data by 1 cell in i directions where appropriate.