### PR TITLE
#216 Bug where velocity sometimes has NaNs in bottom level

### DIFF
--- a/inputs/grid_name_map.json
+++ b/inputs/grid_name_map.json
@@ -40,7 +40,10 @@
             "e3f": "e3f",
             "e3uw": "e3uw",
             "e3vw": "e3vw",
-            "e3fw": "e3fw"
+            "e3fw": "e3fw",
+            "ln_zco": "ln_zco",
+            "ln_zps": "ln_zps",
+            "ln_sco": "ln_sco"
     },
     "dst_variable_map": {
             "nav_lon": "nav_lon",
@@ -77,6 +80,9 @@
             "e3f": "e3f",
             "e3uw": "e3uw",
             "e3vw": "e3vw",
-            "e3fw": "e3fw"
+            "e3fw": "e3fw",
+            "ln_zco": "ln_zco",
+            "ln_zps": "ln_zps",
+            "ln_sco": "ln_sco"
     }
 }

--- a/inputs/grid_name_map_readme.txt
+++ b/inputs/grid_name_map_readme.txt
@@ -75,3 +75,7 @@ In all cases "t" should be size 1. Pybdy does not deal with time varying grids.
 "e3uw" = * vertical scale factor distance between w-levels on u-grid (dims [t, z, y, x])
 "e3vw" = * vertical scale factor distance between w-levels on v-grid (dims [t, z, y, x])
 "e3fw" = * vertical scale factor distance between w-levels on f-grid (dims [t, z, y, x])
+
+"ln_zco" = * flag for zco vertical coordinates 1 for true, 0 for false often provided in domain_cfg.nc
+"ln_zps" = * flag for zps vertical coordinates 1 for true, 0 for false often provided in domain_cfg.nc
+"ln_sco" = * flag for sco vertical coordinates 1 for true, 0 for false often provided in domain_cfg.nc

--- a/inputs/namelist_local.bdy
+++ b/inputs/namelist_local.bdy
@@ -10,6 +10,15 @@
 !!>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 !------------------------------------------------------------------------------
+!   vertical coordinate
+!------------------------------------------------------------------------------
+   sn_src_zgr_type = 'zps' ! vertical coordinate type: 'zco', 'zps' or 'sco'
+   sn_dst_zgr_type = 'zps' ! vertical coordinate type: 'zco', 'zps' or 'sco'
+                           ! 'zco' is z-coordinate - full    steps
+                           ! 'zps' is z-coordinate - partial steps
+                           ! 'sco' is s- or hybrid z-s-coordinate
+
+!------------------------------------------------------------------------------
 !  grid information
 !------------------------------------------------------------------------------
    sn_src_hgr = './inputs/benchmark/grid_low_res_C/mesh_hgr.nc'

--- a/inputs/namelist_remote.bdy
+++ b/inputs/namelist_remote.bdy
@@ -10,6 +10,15 @@
 !!>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 !------------------------------------------------------------------------------
+!   vertical coordinate
+!------------------------------------------------------------------------------
+   sn_src_zgr_type = 'sco' ! vertical coordinate type: 'zco', 'zps' or 'sco'
+   sn_dst_zgr_type = 'sco' ! vertical coordinate type: 'zco', 'zps' or 'sco'
+                           ! 'zco' is z-coordinate - full    steps
+                           ! 'zps' is z-coordinate - partial steps
+                           ! 'sco' is s- or hybrid z-s-coordinate
+
+!------------------------------------------------------------------------------
 !  grid information
 !------------------------------------------------------------------------------
    sn_src_hgr = 'http://opendap4gws.jasmin.ac.uk/thredds/noc_msm/dodsC/pynemo_grid_low_res_C/mesh_hgr.nc'

--- a/src/pybdy/nemo_bdy_extr_assist.py
+++ b/src/pybdy/nemo_bdy_extr_assist.py
@@ -332,6 +332,7 @@ def flood_fill(sc_bdy, isslab, logger):
     sc_shape = sc_bdy.shape
 
     for i in range(sc_shape[0]):
+        # Check if layer centre-point has both nans and values
         while np.isnan(sc_bdy[i, :, 0]).any() & (~np.isnan(sc_bdy[i, :, 0])).any():
             # Flood sc land horizontally within the chunk for the centre point.
             # This may not be perfect but better than filling with zeros
@@ -351,6 +352,12 @@ def flood_fill(sc_bdy, isslab, logger):
             np.isnan(sc_bdy[:, :, 0])
         ]
 
+    # Replace nans around centre-point with value.
+    sc_nan = np.isnan(sc_bdy)
+    sc_bdy[:, :, 1:][sc_nan[:, :, 1:]] = np.tile(sc_bdy[:, :, 0:1], (1, 1, 8))[
+        sc_nan[:, :, 1:]
+    ]
+
     return sc_bdy
 
 
@@ -363,7 +370,7 @@ def interp_vertical(sc_bdy, dst_dep, bdy_bathy, z_ind, z_dist, num_bdy, zinterp=
     sc_bdy (np.array)   : souce data [nz_sc, nbdy, 9]
     dst_dep (np.array)  : the depth of the destination grid chunk [nz, nbdy]
     bdy_bathy (np.array): the destination grid bdy points bathymetry
-    z_ind (np.array)    : the indices of the sc depth above and below bdy
+    z_ind (np.array)    : the indices of the sc depth above and below bdy point
     z_dist (np.array)   : the distance weights of the selected points
     num_bdy (int)       : number of boundary points in chunk
     zinterp (bool)      : vertical interpolation flag

--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -61,8 +61,8 @@ class Extract:
         DstCoord        (obj)  : destination grid information
         Grid            (dict) : containing grid type 't', 'u', 'v' and source time
         var_name        (list) : netcdf file variable names (str)
-        years           (list) : years to extract (default [1979])
-        months          (list) : months to extract (default [11])
+        grd             (str)  : grid to process 't', 'u', 'v'
+        pair            (str)  : None or 'uv'
 
         Returns
         -------
@@ -982,6 +982,7 @@ class Extract:
                         self.logger.info(
                             "%s en to %s %s", self.rot_dir, self.rot_dir, dst_bdy.shape
                         )
+
                         dst_bdy = rot_rep(
                             dst_bdy,
                             dst_bdy_2,

--- a/src/pybdy/nemo_bdy_zgrv2.py
+++ b/src/pybdy/nemo_bdy_zgrv2.py
@@ -169,9 +169,9 @@ def get_bdy_depths(DstCoord, bdy_i, grd):
     bdy_tz = np.ma.zeros((m_t.shape[0], len(g_ind)))
     bdy_e3 = np.ma.zeros((m_e.shape[0], len(g_ind)))
     for k in range(m_w.shape[0]):
-        tmp_w = np.ma.masked_where(mbathy + 1 < k + 1, m_w[k, :, :])
-        tmp_t = np.ma.masked_where(mbathy < k + 1, m_t[k, :, :])
-        tmp_e = np.ma.masked_where(mbathy < k + 1, m_e[k, :, :])
+        tmp_w = np.ma.masked_where(mbathy + 1 < (k + 1), m_w[k, :, :])
+        tmp_t = np.ma.masked_where(mbathy < (k + 1), m_t[k, :, :])
+        tmp_e = np.ma.masked_where(mbathy < (k + 1), m_e[k, :, :])
 
         tmp_w = tmp_w.flatten("F")
         tmp_t = tmp_t.flatten("F")

--- a/src/pybdy/profiler.py
+++ b/src/pybdy/profiler.py
@@ -107,6 +107,7 @@ def process_bdy(setup_filepath=0, mask_gui=False):
     DstCoord.hgr = hgr.H_Grid(settings["dst_hgr"], settings["nme_map"], logger, dst=1)
     DstCoord.zgr = zgr.Z_Grid(
         settings["dst_zgr"],
+        settings["dst_zgr_type"],
         settings["nme_map"],
         DstCoord.hgr.grid_type,
         DstCoord.hgr.grid,
@@ -175,6 +176,7 @@ def process_bdy(setup_filepath=0, mask_gui=False):
     )
     SourceCoord.zgr = zgr.Z_Grid(
         settings["src_zgr"],
+        settings["src_zgr_type"],
         settings["nme_map"],
         SourceCoord.hgr.grid_type,
         SourceCoord.hgr.grid,

--- a/tests/data/grid_name_map.json
+++ b/tests/data/grid_name_map.json
@@ -40,7 +40,10 @@
             "e3f": "e3f",
             "e3uw": "e3uw",
             "e3vw": "e3vw",
-            "e3fw": "e3fw"
+            "e3fw": "e3fw",
+            "ln_zco": "ln_zco",
+            "ln_zps": "ln_zps",
+            "ln_sco": "ln_sco"
     },
     "dst_variable_map": {
             "nav_lon": "nav_lon",
@@ -77,6 +80,9 @@
             "e3f": "e3f",
             "e3uw": "e3uw",
             "e3vw": "e3vw",
-            "e3fw": "e3fw"
+            "e3fw": "e3fw",
+            "ln_zco": "ln_zco",
+            "ln_zps": "ln_zps",
+            "ln_sco": "ln_sco"
     }
 }

--- a/tests/data/namelist_zz_end_to_end.bdy
+++ b/tests/data/namelist_zz_end_to_end.bdy
@@ -10,6 +10,15 @@
 !!>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 !------------------------------------------------------------------------------
+!   vertical coordinate
+!------------------------------------------------------------------------------
+   sn_src_zgr_type = 'zco' ! vertical coordinate type: 'zco', 'zps' or 'sco'
+   sn_dst_zgr_type = 'zco' ! vertical coordinate type: 'zco', 'zps' or 'sco'
+                           ! 'zco' is z-coordinate - full    steps
+                           ! 'zps' is z-coordinate - partial steps
+                           ! 'sco' is s- or hybrid z-s-coordinate
+
+!------------------------------------------------------------------------------
 !  grid information
 !------------------------------------------------------------------------------
    sn_src_hgr = './tests/data/mesh_synth_sc.nc' ! sn_src_hgr = './tests/mesh_hgr.nc'

--- a/tests/test_zgr.py
+++ b/tests/test_zgr.py
@@ -65,7 +65,7 @@ def test_depth_file_zps():
         e_dict = {k: hg.grid[k] for k in keys}
 
         # calc vertical grid
-        zg = zgr.Z_Grid(in_file, name_map, hg.grid_type, e_dict, logger)
+        zg = zgr.Z_Grid(in_file, "zps", name_map, hg.grid_type, e_dict, logger)
 
         nc = GetFile(bench_file)
         e3t = nc.nc["e3t"][:]

--- a/tests/test_zz_end_to_end.py
+++ b/tests/test_zz_end_to_end.py
@@ -44,7 +44,7 @@ def test_zco_zco():
     """
     path1, path2, path3 = generate_sc_test_case(zco=True)
     path4 = generate_dst_test_case(zco=True)
-    name_list_path = modify_namelist(path1, path3, path4)
+    name_list_path = modify_namelist(path1, path3, path4, "zco", "zco")
 
     # Run pybdy
     subprocess.run(
@@ -108,8 +108,8 @@ def test_zco_zco():
         "Sum_mask": 740490,
         "Shape_u": (30, 25, 1, 1566),
         "Shape_v": (30, 25, 1, 1566),
-        "Mean_u": 0.9975701570510864,
-        "Mean_v": 0.9893443584442139,
+        "Mean_u": 0.997593879699707,
+        "Mean_v": 0.9893401861190796,
     }
 
     assert summary_grid == test_grid, "May need to update regression values."
@@ -124,7 +124,7 @@ def test_sco_sco():
     """
     path1, path2, path3 = generate_sc_test_case(zco=False)
     path4 = generate_dst_test_case(zco=False)
-    name_list_path = modify_namelist(path1, path3, path4)
+    name_list_path = modify_namelist(path1, path3, path4, "sco", "sco")
 
     # Run pybdy
     subprocess.run(
@@ -182,14 +182,14 @@ def test_sco_sco():
         "Shape_temp": (30, 15, 1, 1584),
         "Shape_ssh": (30, 1, 1584),
         "Shape_mask": (60, 50),
-        "Mean_temp": 18.054542541503906,
+        "Mean_temp": 18.054527282714844,
         "Mean_sal": 34.12153625488281,
         "Sum_unmask": 665280,
         "Sum_mask": 47520,
         "Shape_u": (30, 15, 1, 1566),
         "Shape_v": (30, 15, 1, 1566),
-        "Mean_u": 0.7764930725097656,
-        "Mean_v": 0.7688539624214172,
+        "Mean_u": 0.7650341987609863,
+        "Mean_v": 0.7656515836715698,
     }
 
     assert summary_grid == test_grid, "May need to update regression values."
@@ -204,7 +204,7 @@ def test_sco_zco():
     """
     path1, path2, path3 = generate_sc_test_case(zco=False)
     path4 = generate_dst_test_case(zco=True)
-    name_list_path = modify_namelist(path1, path3, path4)
+    name_list_path = modify_namelist(path1, path3, path4, "sco", "zco")
 
     # Run pybdy
     subprocess.run(
@@ -262,7 +262,7 @@ def test_sco_zco():
         "Shape_temp": (30, 25, 1, 1584),
         "Shape_ssh": (30, 1, 1584),
         "Shape_mask": (60, 50),
-        "Mean_temp": 18.122085571289062,
+        "Mean_temp": 18.122074127197266,
         "Mean_sal": 34.09104537963867,
         "Sum_unmask": 447510,
         "Sum_mask": 740490,
@@ -285,7 +285,7 @@ def test_wrap_sc():
     """
     path1, path2, path3 = generate_sc_test_case(zco=True, wrap=1)
     path4 = generate_dst_test_case(zco=True)
-    name_list_path = modify_namelist(path1, path3, path4)
+    name_list_path = modify_namelist(path1, path3, path4, "zco", "zco")
 
     # Run pybdy
     subprocess.run(
@@ -609,7 +609,7 @@ def generate_dst_test_case(zco):
     return path1
 
 
-def modify_namelist(path_src, path_sc_data, path_dst):
+def modify_namelist(path_src, path_sc_data, path_dst, src_zgr, dst_zgr):
     # Modify paths in a namelist file for testing.
 
     namelist_file = "./tests/data/namelist_zz_end_to_end.bdy"
@@ -617,11 +617,20 @@ def modify_namelist(path_src, path_sc_data, path_dst):
     with open(namelist_file, "r") as f:
         lines = f.readlines()
         for li in range(len(lines)):
-            if "sn_src_hgr" in lines[li]:
+            if "sn_src_zgr_type" in lines[li]:
+                st = lines[li].split("=")[0]
+                en = lines[li].split("!")[-1]
+                lines[li] = st + "= '" + src_zgr + "' !" + en
+            if "sn_dst_zgr_type" in lines[li]:
+                st = lines[li].split("=")[0]
+                en = lines[li].split("!")[-1]
+                lines[li] = st + "= '" + dst_zgr + "' !" + en
+
+            if "sn_src_hgr " in lines[li]:
                 st = lines[li].split("=")[0]
                 en = lines[li].split("!")[-1]
                 lines[li] = st + "= '" + path_src + "' !" + en
-            if "sn_src_zgr" in lines[li]:
+            if "sn_src_zgr " in lines[li]:
                 st = lines[li].split("=")[0]
                 en = lines[li].split("!")[-1]
                 lines[li] = st + "= '" + path_src + "' !" + en
@@ -630,11 +639,11 @@ def modify_namelist(path_src, path_sc_data, path_dst):
                 en = lines[li].split("!")[-1]
                 lines[li] = st + "= '" + path_src + "' !" + en
 
-            if "sn_dst_hgr" in lines[li]:
+            if "sn_dst_hgr " in lines[li]:
                 st = lines[li].split("=")[0]
                 en = lines[li].split("!")[-1]
                 lines[li] = st + "= '" + path_dst + "' !" + en
-            if "sn_dst_zgr" in lines[li]:
+            if "sn_dst_zgr " in lines[li]:
                 st = lines[li].split("=")[0]
                 en = lines[li].split("!")[-1]
                 lines[li] = st + "= '" + path_dst + "' !" + en


### PR DESCRIPTION
As issue #216 says there were places where a sigma grid had nans in the layer above the bottom. The problem was that the type of vertical coordinates of the parent and child grids was incorrectly being interpreted as zps instead of sco.

To fix this, I have changed the namelist to include user specified zgr type definition. I have also added code that tries to read ln_zco, ln_zps and ln_sco from the domain file and compares with the user defined zgr type. This fixes #216.